### PR TITLE
Add support for Gobbldygook's legacy course format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ There are three scripts: `download.py`, `maintain-datafiles.py`, and `bundle.py`
 
 All of these tools expect the [course data][course-data] to be one folder up from the CWD, in `../course-data`.
 
-These scripts require `python3` >= 3.4, as well as `beautifulsoup4`, `requests`, `xmltodict`. 
+These scripts require `python3` >= 3.4, as well as `beautifulsoup4`, `requests`, `xmltodict`.
 
 The libraries are also specified in the `requirements.txt` file, so a `pip3 install --user -r requirements.txt` should do it. I *highly* reccommend using [Homebrew](https://brew.sh) to install and update Python on macOS.
 
 
 ## `download.py`
-###### Usage: 
+###### Usage:
 
 ```console
 ./download.py
@@ -33,7 +33,7 @@ You can pass a mix of years and terms to `download.py`. A term is a year followe
 
 
 ## `bundle.py`
-###### Usage: 
+###### Usage:
 
 ```console
 ./bundle.py
@@ -46,12 +46,14 @@ You can pass a mix of years and terms to `bundle.py`. A term is a year followed 
 `bundle.py` outputs bundles into `../course-data/terms`.
 
 ###### Arguments:
-- `-w, --workers` — how many processes to spawn
-- `--format (json|csv|xml)` — how to output the bundle
+- `-w` — how many processes to spawn
+- `--format (json|csv|xml)` — how to output the bundle. can be given multiple times to generate multiple formats
+- `--legacy` — create files in the legacy gobbldygook format
+- `--out-dir` — path to a folder to contain the output
 
 
 ## `maintain-datafiles.py`
-###### Usage: 
+###### Usage:
 
 ```console
 ./maintain-datafiles.py

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -30,9 +30,10 @@ fi
 git checkout -B gh-pages master --no-track
 
 # update bundled information for public consumption
-python3 ../bundle.py --format json xml csv
+python3 ../bundle.py --out-dir ../course-data --format json --format xml --format csv
+python3 ../bundle.py --legacy --out-dir ../course-data/legacy --format json
 
-# remove the source files ([-q]uietly)
+# remove the source files (quietly)
 git rm -rf --quiet courses/ details/ raw_xml/
 
 # and … push

--- a/bundle.py
+++ b/bundle.py
@@ -11,7 +11,7 @@ from lib.calculate_terms import calculate_terms
 from lib.regress_course import regress_course
 from lib.load_courses import load_some_courses
 from lib.save_term import save_term
-from lib.paths import term_dest
+from lib.paths import COURSE_DATA
 from lib.log import log
 from lib.paths import term_clbid_mapping_path
 
@@ -52,7 +52,7 @@ def run(args):
     else:
         list(map(edit_one_term, terms))
 
-    json_folder_map(folder=args.out_dir, path=args.out_dir)
+    json_folder_map(root=args.out_dir, folder='terms', name='index' if not args.legacy else 'legacy')
 
 
 def main():
@@ -63,25 +63,29 @@ def main():
                            type=int,
                            nargs='*',
                            help='Terms (or entire years) for which to request data from the SIS')
-    argparser.add_argument('--workers', '-w',
+    argparser.add_argument('-w',
+                           metavar='WORKERS',
                            type=int,
                            default=cpu_count(),
-                           help='Control the number of operations to perform in parallel')
+                           help='The number of operations to perform in parallel')
     argparser.add_argument('--legacy',
-                           type='store_true',
+                           action='store_true',
                            help="Use legacy mode (you don't need this)")
-    argparser.add_argument('--out-dir', '-o',
-                           type='store',
-                           default=term_dest,
-                           help='Change the root term output directory')
-    argparser.add_argument('--format',
+    argparser.add_argument('--out-dir',
+                           nargs='?',
                            action='store',
-                           nargs='+',
-                           default=['json'],
+                           default=COURSE_DATA,
+                           help='Where to put info.json and terms/')
+    argparser.add_argument('--format',
+                           action='append',
+                           nargs='?',
                            choices=['json', 'csv', 'xml'],
                            help='Change the output filetype')
 
-    run(argparser.parse_args())
+    args = argparser.parse_args()
+    args.format = ['json'] if not args.format else args.format
+
+    run(args)
 
 
 if __name__ == '__main__':

--- a/bundle.py
+++ b/bundle.py
@@ -8,6 +8,7 @@ import os
 
 from lib.json_folder_map import json_folder_map
 from lib.calculate_terms import calculate_terms
+from lib.regress_course import regress_course
 from lib.load_courses import load_some_courses
 from lib.save_term import save_term
 from lib.paths import term_dest
@@ -28,6 +29,10 @@ def one_term(args, term):
 
     log(pretty_term, 'Loading courses')
     courses = list(load_some_courses(term))
+
+    if args.legacy:
+      for c in courses:
+        regress_course(c)
 
     log(pretty_term, 'Saving term')
     for f in args.format:
@@ -62,6 +67,9 @@ def main():
                            type=int,
                            default=cpu_count(),
                            help='Control the number of operations to perform in parallel')
+    argparser.add_argument('--legacy',
+                           type='store_true',
+                           help="Use legacy mode (you don't need this)")
     argparser.add_argument('--out-dir', '-o',
                            type='store',
                            default=term_dest,

--- a/bundle.py
+++ b/bundle.py
@@ -31,7 +31,7 @@ def one_term(args, term):
 
     log(pretty_term, 'Saving term')
     for f in args.format:
-        save_term(term, courses, kind=f)
+        save_term(term, courses, kind=f, root_path=args.out_dir)
 
 
 def run(args):
@@ -47,7 +47,7 @@ def run(args):
     else:
         list(map(edit_one_term, terms))
 
-    json_folder_map(folder=term_dest, path=term_dest)
+    json_folder_map(folder=args.out_dir, path=args.out_dir)
 
 
 def main():
@@ -62,6 +62,10 @@ def main():
                            type=int,
                            default=cpu_count(),
                            help='Control the number of operations to perform in parallel')
+    argparser.add_argument('--out-dir', '-o',
+                           type='store',
+                           default=term_dest,
+                           help='Change the root term output directory')
     argparser.add_argument('--format',
                            action='store',
                            nargs='+',

--- a/lib/json_folder_map.py
+++ b/lib/json_folder_map.py
@@ -3,23 +3,22 @@ import hashlib
 import json
 import os
 
-from .paths import info_path
 from .log import log
 
 
-def json_folder_map(folder, path, dry_run=False):
+def json_folder_map(root, folder, name='index', dry_run=False):
     output = {
         'files': [],
         'type': 'courses',
     }
 
-    files = os.scandir(folder)
+    files = os.scandir(os.path.join(root, folder))
     for file in files:
         filename = file.name
         if filename.startswith('.'):
             continue
 
-        filepath = os.path.join(folder, filename)
+        filepath = os.path.join(root, folder, filename)
         with open(filepath, 'rb') as infile:
             basename, extension = os.path.splitext(filename)
             extension = extension[1:]  # splitext's extension includes the preceding dot
@@ -38,8 +37,11 @@ def json_folder_map(folder, path, dry_run=False):
     output = OrderedDict(sorted(output.items()))
 
     log('Hashed files')
-    if not dry_run:
-        with open(info_path, 'w') as outfile:
-            outfile.write(json.dumps(output, indent='\t', separators=(',', ': ')))
-            outfile.write('\n')
-            log('Wrote index.json to', info_path)
+    if dry_run:
+        return
+
+    index_path = os.path.join(root, '{}.json'.format(name))
+    with open(index_path, 'w') as outfile:
+        json.dump(output, outfile, indent='\t', separators=(',', ': '))
+        outfile.write('\n')
+        log('Wrote index.json to', index_path)

--- a/lib/paths.py
+++ b/lib/paths.py
@@ -4,8 +4,7 @@ COURSE_DATA = join('..', 'course-data')
 details_source = join(COURSE_DATA, 'details')
 xml_source = join(COURSE_DATA, 'raw_xml')
 course_dest = join(COURSE_DATA, 'courses')
-info_path = join(COURSE_DATA, 'index.json')
-term_dest = join(COURSE_DATA, 'terms')
+term_dest = join(COURSE_DATA)
 mappings_path = join(COURSE_DATA, 'data-lists')
 handmade_path = join(COURSE_DATA, 'data-mappings')
 term_clbid_mapping_path = join(COURSE_DATA, 'courses', '_index')
@@ -36,5 +35,5 @@ def make_xml_term_path(term):
     return join(xml_source, str(term) + '.xml')
 
 
-def make_built_term_path(term, kind, folder):
-    return join(folder, '{}.{}'.format(term, kind))
+def make_built_term_path(term, kind):
+    return '{}.{}'.format(term, kind)

--- a/lib/paths.py
+++ b/lib/paths.py
@@ -36,5 +36,5 @@ def make_xml_term_path(term):
     return join(xml_source, str(term) + '.xml')
 
 
-def make_built_term_path(term, kind, folder=term_dest):
-    return join(folder, '%d.%s' % (term, kind))
+def make_built_term_path(term, kind, folder):
+    return join(folder, '{}.{}'.format(term, kind))

--- a/lib/regress_course.py
+++ b/lib/regress_course.py
@@ -1,0 +1,9 @@
+def regress_course(course):
+    course['depts'] = course['departments']
+    del course['departments']
+    course['desc'] = course['description']
+    del course['description']
+    course['num'] = course['number']
+    del course['number']
+    course['pf'] = course['pn']
+    del course['pn']

--- a/lib/regress_course.py
+++ b/lib/regress_course.py
@@ -1,9 +1,13 @@
 def regress_course(course):
-    course['depts'] = course['departments']
-    del course['departments']
-    course['desc'] = course['description']
-    del course['description']
-    course['num'] = course['number']
-    del course['number']
-    course['pf'] = course['pn']
-    del course['pn']
+    if 'departments' in course:
+        course['depts'] = course['departments']
+        del course['departments']
+    if 'description' in course:
+        course['desc'] = course['description']
+        del course['description']
+    if 'number' in course:
+        course['num'] = course['number']
+        del course['number']
+    if 'pn' in course:
+        course['pf'] = course['pn']
+        del course['pn']

--- a/lib/save_term.py
+++ b/lib/save_term.py
@@ -25,11 +25,12 @@ def save_xml_term(term_path, courses):
     save_data(xml_term_data + '\n', term_path)
 
 
-def save_term(term, courses, kind):
+def save_term(term, courses, kind, root_path):
     if not courses:
         return
 
-    term_path = make_built_term_path(term, kind)
+    term_path = make_built_term_path(term, kind, root_path)
+
     print('saving term', term, 'to', term_path)
     if kind == 'json':
         save_json_term(term_path, courses)

--- a/lib/save_term.py
+++ b/lib/save_term.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from .log import log
 from .save_data import save_data
@@ -29,7 +30,7 @@ def save_term(term, courses, kind, root_path):
     if not courses:
         return
 
-    term_path = make_built_term_path(term, kind, root_path)
+    term_path = os.path.join(root_path, 'terms', make_built_term_path(term, kind))
 
     print('saving term', term, 'to', term_path)
     if kind == 'json':


### PR DESCRIPTION
> `--legacy` will hopefully not be needed anymore, after this weekend.
##### Changes

`bundle.py --format csv json` is now `bundle.py --format csv --format json`, in order to clarify which parameters belong to the `--format` argument and which are terms.

`bundle.py` now accepts a `--legacy` flag, which changes the course format slightly, to be compatible with the "legacy" gobbldygook format. I've been trying to move Gobbldygook away from it, but it's not done and the old hosting went away today.
##### Internal Changes

`json_folder_map` now takes a `root` parameter, which is a folder where it will put the `index.json` file, and a `folder` parameter, which is a subfolder of the `root` directory that it will scan for the `index.json` file.

`--workers` is now only available through the `-w` argument. Same purpose, shorter name.
