### PR TITLE
Add sentry monitoring for the update workflow

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -55,7 +55,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.COURSE_DATA_TOOLS_GH_SENTRY_DSN }}
           TARGET_ENV: 'production'
 
-      - name: Report failure
+      - name: Check for errors
         if: github.event_name == 'schedule' && failure()
         run: bash bin/monitor.sh fail
         env:

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -19,6 +19,13 @@ jobs:
         python-version: ["3.7"]
 
     steps:
+      - name: Start check-in
+        if: github.event_name == 'schedule'
+        run: bash bin/monitor.sh start
+        env:
+          SENTRY_DSN: ${{ secrets.COURSE_DATA_TOOLS_GH_SENTRY_DSN }}
+          TARGET_ENV: 'production'
+
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.COURSE_DATA_TOOLS_GH_PUSH_TOKEN }}
@@ -40,3 +47,17 @@ jobs:
           GITHUB_BRANCH: ${{ github.ref_name }}
           head_ref: ${{ github.ref }}
           GITHUB_OAUTH: ${{ secrets.COURSE_DATA_TOOLS_GH_PUSH_TOKEN }}
+
+      - name: Finish check-in
+        if: github.event_name == 'schedule'
+        run: bash bin/monitor.sh stop
+        env:
+          SENTRY_DSN: ${{ secrets.COURSE_DATA_TOOLS_GH_SENTRY_DSN }}
+          TARGET_ENV: 'production'
+
+      - name: Report failure
+        if: github.event_name == 'schedule' && failure()
+        run: bash bin/monitor.sh fail
+        env:
+          SENTRY_DSN: ${{ secrets.COURSE_DATA_TOOLS_GH_SENTRY_DSN }}
+          TARGET_ENV: 'production'

--- a/bin/monitor.sh
+++ b/bin/monitor.sh
@@ -15,7 +15,7 @@ function start() {
         "$SENTRY_API_URL" \
         --header "$SENTRY_AUTH_HEADER" \
         --header "$CONTENT_TYPE_HEADER" \
-        --data-raw '{"status": "in_progress", "environment": "'$CURRENT_ENV'"}'
+        --data-raw "$(jq -n --arg env "$CURRENT_ENV" '{status: "in_progress", environment: $env}')"
 }
 
 function stop() {
@@ -23,7 +23,7 @@ function stop() {
         "$SENTRY_API_LATEST_URL" \
         --header "$SENTRY_AUTH_HEADER" \
         --header "$CONTENT_TYPE_HEADER" \
-        --data-raw '{"status": "ok", "environment": "'$CURRENT_ENV'"}'
+        --data-raw "$(jq -n --arg env "$CURRENT_ENV" '{status: "ok", environment: $env}')"
 }
 
 function fail() {
@@ -31,7 +31,7 @@ function fail() {
         "$SENTRY_API_LATEST_URL" \
         --header "$SENTRY_AUTH_HEADER" \
         --header "$CONTENT_TYPE_HEADER" \
-        --data-raw '{"status": "error", "environment": "'$CURRENT_ENV'"}'
+        --data-raw "$(jq -n --arg env "$CURRENT_ENV" '{status: "error", environment: $env}')"
 }
 
 function report_status() {

--- a/bin/monitor.sh
+++ b/bin/monitor.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -ve
+
+CURRENT_ENV="${TARGET_ENV:-dev}"
+
+SENTRY_API_URL='https://sentry.io/api/0/organizations/frog-pond-labs/monitors/course-data-tools/checkins/'
+SENTRY_API_LATEST_URL="${SENTRY_API_URL%/}/latest/"
+
+SENTRY_AUTH_HEADER="Authorization: DSN $SENTRY_DSN"
+CONTENT_TYPE_HEADER='Content-Type: application/json'
+
+function start() {
+    curl -X POST \
+        "$SENTRY_API_URL" \
+        --header "$SENTRY_AUTH_HEADER" \
+        --header "$CONTENT_TYPE_HEADER" \
+        --data-raw '{"status": "in_progress", "environment": "'$CURRENT_ENV'"}'
+}
+
+function stop() {
+    curl -X PUT \
+        "$SENTRY_API_LATEST_URL" \
+        --header "$SENTRY_AUTH_HEADER" \
+        --header "$CONTENT_TYPE_HEADER" \
+        --data-raw '{"status": "ok", "environment": "'$CURRENT_ENV'"}'
+}
+
+function fail() {
+    curl -X PUT \
+        "$SENTRY_API_LATEST_URL" \
+        --header "$SENTRY_AUTH_HEADER" \
+        --header "$CONTENT_TYPE_HEADER" \
+        --data-raw '{"status": "error", "environment": "'$CURRENT_ENV'"}'
+}
+
+function report_status() {
+    if [ "$1" = "start" ]; then
+        start
+    elif [ "$1" = "stop" ]; then
+        stop
+    elif [ "$1" = "fail" ]; then
+        fail
+    else
+        echo "Invalid argument. Usage: report_status [start|stop|fail]"
+    fi
+}
+
+report_status "$1"


### PR DESCRIPTION
## Brief

- Support for monitoring the start, stop, and failure cases of the `update-data` workflow
- [Sentry `http` cron docs](https://docs.sentry.io/product/crons/getting-started/http/)

## Tell me more

Process
- Adds a monitoring healthcheck script that talks to Sentry cron monitoring.
- Added a new project underneath the Sentry dashboard for `cron-alerts`
- Checks-in for `start`, `stop`, and if an error occurred, `fail`

Sentry config
  - Check-in is expected once a day (set up to avoid changes on either end making noise)
  - Missed status interval is set to one hour (default is 30 minutes)
  - A failed status is reported after 30 minutes (default is 0 minutes)  

Alerts and secrets
- Alerts are set up to only be delivered to myself at the moment, feel free to opt-in if you want to be notified
- Secrets and variables:
    - `secrets.COURSE_DATA_TOOLS_GH_SENTRY_DSN` contains the DSN that sentry uses for auth/identification
    - `TARGET_ENV` identifies whether we're running locally (local: `dev`, scheduled action:`production`)

Usage
```
scripts/monitor.sh [start|stop|fail]
```

Testing
- I've run these three processes and observed dashboard data and notifications sent out  
- I've not yet run the GitHub Actions workflow, we can see if that is setup
   
---

Notes
- Sentry also supports usage of [a heartbeat for a single check-in](https://docs.sentry.io/product/crons/getting-started/http/#heartbeat). I'd say for now we can try a much more active canary (start/stop/fail) and if it doesn't fit, we can adjust.