### PR TITLE
catch value error exceptions for course credit parsing

### DIFF
--- a/lib/process_courses.py
+++ b/lib/process_courses.py
@@ -108,7 +108,10 @@ def clean_course(course):
         course['number'] = course['coursenumber']
     del course['coursenumber']
 
-    course['credits'] = float(course['credits'])
+    try:
+        course['credits'] = float(course['credits'])
+    except ValueError:
+        course['credits'] = -1.0
 
     course['enrolled'] = int(course['enroll'])
     del course['enroll']


### PR DESCRIPTION
An error occurs when trying to parse `('credits', 'Var')`

BIO 306 in 2023:3
crsid: 0000038367
clbid: 0000155837

```
✦ ❯ python3 download.py --force-terms -w 1 20233
2023:3 Processing term
Traceback (most recent call last):
  File "lib/process_courses.py", line 112, in clean_course
    course['credits'] = float(course['credits'])
                        ^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: could not convert string to float: 'Var'
```

We can guard against the mythical variable-credit course instead.