### PR TITLE
Revert requests from 2.32.0 to 2.31.0 

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Check dependencies and lint
+name: Check dependencies
 on:
   push: {branches: [master]}
   pull_request:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,5 +21,3 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Lint
-        uses: py-actions/flake8@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,29 @@
+name: Check dependencies and lint
+on:
+  push: {branches: [master]}
+  pull_request:
+jobs:
+  check-deps-and-lint:
+    name: Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        python-version: ["3.7"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        uses: microsoft/action-python@0.7.2
+        with:
+          python_version: 3.7
+          flake8: true
+          fail_on_error: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,8 +22,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Lint
-        uses: microsoft/action-python@0.7.2
-        with:
-          python_version: 3.7
-          flake8: true
-          fail_on_error: true
+        uses: py-actions/flake8@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.9.1
-requests==2.32.0
+requests==2.31.0
 xmltodict==0.12.0
 pylint==2.5.3
 pytest==5.4.3


### PR DESCRIPTION
This reverts commit 7acdc201da63b394455e0e759036469d88a2e374 which has broken GitHub CI/CD since 05/22/2024.

Looks like 2.32.0 was a [buggy release](https://github.com/psf/requests/issues/6706) quickly replaced by `2.32.1/2` so we should revert.

[The latest run](https://github.com/StoDevX/course-data-tools/actions/runs/9239991098/job/25419767742) errors out due to `requests@2.32.0`

```
 Could not find a version that satisfies the requirement requests==2.32.0 
 ```
 
The issue looks to have started with 
- https://github.com/StoDevX/course-data-tools/pull/14