### PR TITLE
upgrade action versions

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.7"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.COURSE_DATA_TOOLS_GH_PUSH_TOKEN }}
 
@@ -32,7 +32,7 @@ jobs:
           TARGET_ENV: 'production'
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'


### PR DESCRIPTION
* bump `actions/setup-python@v5`
* bump `actions/checkout@v4`

Fixes
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.