### PR TITLE
Bump python versions in workflows to 3.7.17

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7.17"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7.17"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ There are three scripts: `download.py`, `maintain-datafiles.py`, and `bundle.py`
 
 All of these tools expect the [course data][course-data] to be one folder up from the CWD, in `../course-data`.
 
-These scripts require `python3` >= 3.7, as well as `beautifulsoup4`, `requests`, `xmltodict`.
+These scripts require `python3` >= 3.7.17, as well as `beautifulsoup4`, `requests`, `xmltodict`.
 
 The libraries are also specified in the `Pipfile` file, so a `pip3 install pipenv` and `pipenv run $command`
 


### PR DESCRIPTION
bump python to 3.7.17 to fix failure where 3.7 with arch x64 was not found