### PR TITLE
Bump python versions in workflows to 3.8

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7.17"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.7.17"]
+        python-version: ["3.8"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7.17"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.7.17"]
+        python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ There are three scripts: `download.py`, `maintain-datafiles.py`, and `bundle.py`
 
 All of these tools expect the [course data][course-data] to be one folder up from the CWD, in `../course-data`.
 
-These scripts require `python3` >= 3.7.17, as well as `beautifulsoup4`, `requests`, `xmltodict`.
+These scripts require `python3` >= 3.8, as well as `beautifulsoup4`, `requests`, `xmltodict`.
 
 The libraries are also specified in the `Pipfile` file, so a `pip3 install pipenv` and `pipenv run $command`
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ There are three scripts: `download.py`, `maintain-datafiles.py`, and `bundle.py`
 
 All of these tools expect the [course data][course-data] to be one folder up from the CWD, in `../course-data`.
 
-These scripts require `python3` >= 3.7, as well as `beautifulsoup4`, `requests`, `xmltodict`.
+These scripts require `python3` >= 3.7.17, as well as `beautifulsoup4`, `requests`, `xmltodict`.
 
 The libraries are also specified in the `Pipfile` file, so a `pip3 install pipenv` and `pipenv run $command`
 


### PR DESCRIPTION
bump python to 3.8 to fix failure where 3.7 with arch x64 was not found

> Course Data Update (3.7)The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04. The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
>
> ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636